### PR TITLE
Remove host permission as it is not needed

### DIFF
--- a/io.gitlab.persiangolf.voicegen.yml
+++ b/io.gitlab.persiangolf.voicegen.yml
@@ -7,7 +7,6 @@ finish-args:
   - --share=ipc
   - --socket=fallback-x11
   - --socket=wayland
-  - --filesystem=host
   - --device=dri
   - --socket=pulseaudio
   - --share=network


### PR DESCRIPTION
The application already is able to use flatpak portals for saving files anywhere, so the host permission is not needed.